### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 A Model Context Protocol (MCP) server for SAP HANA database integration with AI agents like Claude Desktop.
 
-
+<a href="https://glama.ai/mcp/servers/@HatriGt/hana-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@HatriGt/hana-mcp-server/badge" alt="HANA Cloud Server MCP server" />
+</a>
 
 ## 🚀 Features
 


### PR DESCRIPTION
This PR adds a badge for the [HANA Cloud MCP Server](https://glama.ai/mcp/servers/@HatriGt/hana-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@HatriGt/hana-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@HatriGt/hana-mcp-server/badge" alt="HANA Cloud Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.