### PR TITLE
[FEAT] Release 0.3.1 — 11 extended discovery tools & HANA Cloud fixes

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,7 @@
 {
   "MD013": false,
   "MD024": false,
+  "MD029": false,
   "MD051": false,
   "MD060": { "style": "padded" }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented here. Versions follow [Semantic Versioning](https://semver.org/).
 
-> **Note:** If you mean “version 2” informally, this package line is **`0.2.x`** (there is no `2.0.0` tag). This log starts at **`0.2.0`**.
+> **Note:** If you mean “version 2” informally, the package line is **`0.x`** (there is no `2.0.0` tag). This log starts at **`0.2.0`**; the current release is **`0.3.1`**.
 
 ## [Unreleased]
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | Document | Purpose |
 |----------|---------|
 | This README | Prerequisites, install, **how to wire each client**, capability summary, configuration cheat sheet, troubleshooting |
-| [CHANGELOG.md](CHANGELOG.md) | **Release history** — features and fixes by version (`0.2.x`, latest `0.2.2`) |
+| [CHANGELOG.md](CHANGELOG.md) | **Release history** — features and fixes by version (latest `0.3.1`) |
 | [docs/README.md](docs/README.md) | Index of `/docs` |
 | [docs/ENVIRONMENT.md](docs/ENVIRONMENT.md) | **Authoritative** env reference: every variable, defaults, **hard bounds**, HTTP auth, security notes |
 | [docs/configuration-samples.md](docs/configuration-samples.md) | **Copy-paste**: connection profiles (single-container, MDC), semantics JSON, paging pointers |
@@ -175,15 +175,19 @@ Further notes: [ENVIRONMENT.md §9](docs/ENVIRONMENT.md#9-security-notes).
 
 ## 🎯 Capabilities
 
-| Area | What callers get |
-|------|-------------------|
-| **Schema** | Paged schema/table lists, column metadata, connectivity checks |
-| **SQL** | Parameterized execution; optional row/column/cell caps; paging via `maxRows`/`offset`/`includeTotal`; continuation via `hana_query_next_page` |
-| **Discovery (core)** | `hana_list_constraints`, `hana_list_foreign_keys`, `hana_get_table_stats`, `hana_get_sample_data`, `hana_search_columns`, `hana_list_views`, `hana_describe_view`, `hana_list_synonyms`, `hana_list_procedures`, `hana_describe_procedure`, `hana_explain_plan`, `hana_list_privileges` |
-| **Discovery (extended)** | `hana_get_ddl`, `hana_get_column_stats`, `hana_list_functions`, `hana_describe_function`, `hana_list_calculation_views`, `hana_get_session_info`, `hana_search_tables`, `hana_get_expensive_queries`, `hana_get_dependencies`, `hana_get_partition_info`, `hana_list_sequences` |
-| **DML guard** | INSERT / UPDATE / DELETE / TRUNCATE blocked by default; opt-in per operation via `HANA_ALLOW_*` |
-| **Resources** | `hana:///` URIs for list/read; large payloads flagged with `truncated` metadata |
-| **Domain knowledge (optional)** | JSON overlay for **`hana_explain_table`** — [configuration-samples.md](docs/configuration-samples.md) |
+**34 tools** across six areas, all verified on HANA Cloud.
+
+| Area | Tools | What you get |
+|------|-------|--------------|
+| **Connection & config** | `hana_show_config` `hana_test_connection` `hana_show_env_vars` `hana_get_session_info` | Verify connectivity, inspect configuration, see current user / schema / database / version |
+| **Schema browsing** | `hana_list_schemas` `hana_list_tables` `hana_describe_table` `hana_explain_table` `hana_search_tables` `hana_search_columns` | Paginated schema/table lists, column metadata, cross-schema search, optional business-meaning overlay |
+| **SQL execution** | `hana_execute_query` `hana_query_next_page` | Parameterized SQL with optional row/column/cell caps, paging (`maxRows`/`offset`/`includeTotal`), and snapshot continuation |
+| **Structural analysis** | `hana_list_constraints` `hana_list_foreign_keys` `hana_list_indexes` `hana_describe_index` `hana_list_views` `hana_describe_view` `hana_list_synonyms` `hana_list_privileges` `hana_get_ddl` | PK/UK/FK/check constraints, indexes, views with SQL definition, synonyms, effective privileges, CREATE statement DDL |
+| **Code objects** | `hana_list_procedures` `hana_describe_procedure` `hana_list_functions` `hana_describe_function` `hana_list_calculation_views` `hana_list_sequences` | Stored procedures, scalar/table functions, SAP BW/S4 calculation views (`_SYS_BIC`), sequences |
+| **Data & performance** | `hana_get_table_stats` `hana_get_sample_data` `hana_get_column_stats` `hana_explain_plan` `hana_get_dependencies` `hana_get_partition_info` `hana_get_expensive_queries` | Row counts, sample rows, distinct/null stats, query execution plan, object dependency graph, partition info, top expensive statements |
+| **DML guard** | — | INSERT / UPDATE / DELETE / TRUNCATE **blocked by default**; opt-in individually via `HANA_ALLOW_INSERT` / `HANA_ALLOW_UPDATE` / `HANA_ALLOW_DELETE` |
+| **Resources** | `hana:///schemas` `hana:///schemas/{s}/tables/{t}` | MCP resource URIs for schema and table enumeration; `truncated` flag on large payloads |
+| **Domain knowledge** | via `hana_explain_table` | Optional JSON semantics overlay (table descriptions, column meanings, code-value maps) — [configuration-samples.md](docs/configuration-samples.md) |
 
 ---
 
@@ -336,12 +340,12 @@ npx hana-mcp-ui
 
 ![HANA MCP Server Architecture](docs/hana_mcp_architecture.svg)
 
-```
+```text
 hana-mcp-server/
 ├── src/
 │   ├── server/           # MCP lifecycle, resources, HTTP transport
-│   ├── tools/            # Schema, table, query, index, config tools
-│   ├── database/         # HANA client, connection manager, executor, query runner
+│   ├── tools/            # 34 tools: schema, SQL, discovery, config
+│   ├── database/         # HANA client, connection pool, executor, query runner
 │   ├── semantics/        # Optional semantics / domain JSON loader
 │   ├── utils/            # Logger, config, validators, formatters
 │   ├── query-snapshot-store.js

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -191,7 +191,7 @@ Used by [`src/server/http-index.js`](../src/server/http-index.js) and [`src/serv
 | Connection pool | `HANA_CONNECTION_POOL_SIZE` |
 | Audit logging | `HANA_AUDIT_ENABLED`, `HANA_AUDIT_LOG_FILE` |
 | DML restrictions | `HANA_ALLOW_INSERT`, `HANA_ALLOW_UPDATE`, `HANA_ALLOW_DELETE` |
-| Extended discovery (0.3.1) | `hana_get_ddl`, `hana_get_column_stats`, `hana_list_functions`, `hana_describe_function`, `hana_list_calculation_views`, `hana_get_session_info`, `hana_search_tables`, `hana_get_expensive_queries`, `hana_get_dependencies`, `hana_get_partition_info`, `hana_list_sequences` — no additional env vars; `hana_get_expensive_queries` requires MONITORING privilege |
+| Extended discovery (0.3.1) | No extra env vars. `hana_get_expensive_queries` requires MONITORING privilege on the connected user. |
 | `hana_list_schemas` / `hana_list_tables` | `HANA_LIST_DEFAULT_LIMIT` |
 | `hana_explain_table` (business/domain semantics JSON) | `HANA_SEMANTICS_PATH`, `HANA_SEMANTICS_URL`, `HANA_SEMANTICS_TTL_MS`, `HANA_METADATA_CATALOG_DATABASE`, tool `catalog_database` |
 | `hana:///` resources | `HANA_RESOURCE_LIST_MAX_ITEMS` (and HANA connectivity) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 | Document | Audience | Content |
 |----------|----------|---------|
-| [CHANGELOG.md](../CHANGELOG.md) | Integrators, release notes | Versioned feature list (`0.2.x`, latest `0.2.2`) |
+| [CHANGELOG.md](../CHANGELOG.md) | Integrators, release notes | Versioned feature list (`0.2.x`–`0.3.x`, latest `0.3.1`) |
 | [ENVIRONMENT.md](ENVIRONMENT.md) | Operators, security reviewers | Every environment variable, defaults, hard bounds, HTTP auth, security notes |
 | [configuration-samples.md](configuration-samples.md) | Integrators | Connection profile JSON, semantics JSON, env snippets for MCP clients |
 | [local-http-mcp.md](local-http-mcp.md) | IDE users (e.g. Cursor) | Run `npm run start:http`, wire MCP over `POST /mcp`, smoke checks |


### PR DESCRIPTION
## Type of Change
Please select the type of change:
- [X] New feature 💪🏻
- [ ] Bug fix 🐞
- [ ] Other (please specify):🤷🏼

## JIRA Task Link
N/A

## Description of Changes 📄

Adds 11 extended discovery tools for deep HANA introspection, fixes HANA Cloud–specific catalog column differences found during live testing, and cleans up all markdown docs to reflect v0.3.1.

**11 new tools:**
- `hana_get_ddl` — DDL (CREATE statement) for any object via `SYS.OBJECT_DEFINITION`
- `hana_get_column_stats` — cached column statistics or live `COUNT(DISTINCT)` / null-count
- `hana_list_functions` / `hana_describe_function` — scalar and table functions
- `hana_list_calculation_views` — SAP calculation views from `_SYS_BIC`
- `hana_get_session_info` — current user, schema, database name, HANA version
- `hana_search_tables` — cross-schema table-name search by LIKE pattern
- `hana_get_expensive_queries` — top N statements from `M_EXPENSIVE_STATEMENTS`
- `hana_get_dependencies` — object dependency graph from `SYS.OBJECT_DEPENDENCIES`
- `hana_get_partition_info` — partition metadata from `SYS.TABLE_PARTITIONS`
- `hana_list_sequences` — sequences with start/min/max/increment/cycle/cache

**HANA Cloud catalog fixes (discovered via live testing):**
- `SYS.VIEWS.IS_READ_ONLY` (was `READ_ONLY`) — affects views and calculation views
- `SYS.TABLE_PARTITIONS` column rename: `LEVEL_1/2/3_PARTITION`, `LOAD_UNIT` (was `LEVEL`/`LEVELTYPE`/`LEVELNAME`/`RECORD_COUNT`/`LOADED`)
- `M_EXPENSIVE_STATEMENTS.DB_USER` (was `USER_NAME`)
- `SYS.PROCEDURES.RESULT_SET_COUNT` (was `HAS_RESULT_SET`)

**Docs:** All markdown synced to v0.3.1 — version references, capabilities table, quick-reference, lint warnings resolved.

## Other Features Likely to be Affected

Existing tools `hana_list_views`, `hana_describe_view`, `hana_list_procedures`, `hana_get_partition_info` receive bug fixes for HANA Cloud column names.

## Testing
- [X] I tested the branch
- [X] All 11 new tools verified against live HANA Cloud instance
- [X] All pre-existing tools still pass live integration tests
- [X] `npm test` passes (unit + integration)